### PR TITLE
Enable automatic slash command registration

### DIFF
--- a/discord-bot/bot-modular.js
+++ b/discord-bot/bot-modular.js
@@ -57,9 +57,8 @@ client.once('clientReady', async () => {
     // Make client available globally for API routes
     global.discordClient = client;
     
-    // Skip automatic slash command registration to test command listing
-    console.log('⏭️ Skipping automatic slash command registration');
-    writeLog('Bot started without automatic slash command registration', 'Debug');
+    // Register slash commands
+    await registerSlashCommands();
 });
 
 client.on('interactionCreate', async (interaction) => {


### PR DESCRIPTION
Removed the option to skip automatic slash command registration and added the registration process. The old code appeared to be debug code left by the maintainer and not corrected before being pushed to the repo.